### PR TITLE
Fix Firebase module imports

### DIFF
--- a/public/code/auth.js
+++ b/public/code/auth.js
@@ -20,7 +20,7 @@ import {
   uploadBytes,
   getDownloadURL
 } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-storage.js';
-import firebaseConfig from '../Firebase/firebase-config.js';
+import firebaseConfig from '../firebase/firebase-config.js';
 import { setUser, clearUser, updateProfile } from './user-cache.js';
 
 const app = initializeApp(firebaseConfig);

--- a/public/firebase/firebase-config.js
+++ b/public/firebase/firebase-config.js
@@ -1,10 +1,10 @@
 // public/firebase/firebase-config.js
 
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
-import { getDatabase } from 'firebase/database';
-import { getAuth } from 'firebase/auth';
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-app.js';
+import { getAnalytics } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-analytics.js';
+import { getDatabase } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-database.js';
+import { getAuth } from 'https://www.gstatic.com/firebasejs/9.6.7/firebase-auth.js';
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional


### PR DESCRIPTION
## Summary
- load Firebase SDK modules via CDN URLs
- fix case-sensitive path to firebase-config.js

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683c5871642483319abfeefe862b83fc