### PR TITLE
Implement login redirect for chat

### DIFF
--- a/public/code/auth.js
+++ b/public/code/auth.js
@@ -341,11 +341,11 @@ document.addEventListener('app:userLoggedIn', (event) => {
     } else if (needsVerification) {
          popupNotifier.info('Revisa tu correo para verificar tu cuenta antes de iniciar sesión.', 'Verificar correo');
     } else if (user && user.emailVerified && window.location.pathname.startsWith('/auth/login') && !loginRedirectTriggered) {
-        // Only redirect if login was truly successful, we're on the login page,
-        // and we haven't already triggered the redirect
-          popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
+        popupNotifier.success('¡Inicio de sesión exitoso! Redirigiendo...', 'Inicio exitoso');
         loginRedirectTriggered = true;
-        window.location.href = '/inicio/landing.html';
+        const redirect = sessionStorage.getItem('redirectAfterLogin');
+        if (redirect) sessionStorage.removeItem('redirectAfterLogin');
+        window.location.href = redirect || '/inicio/landing.html';
     }
 });
 

--- a/public/code/chatSystem/chat-ui.js
+++ b/public/code/chatSystem/chat-ui.js
@@ -1,4 +1,5 @@
 import { startNewChatWithUser } from './astranetSDKChat.js';
+import { isLoggedIn } from '../user-cache.js';
 
 // UID of the default assistant account used for new conversations
 const DEFAULT_PARTNER_UID = 'astranet-assistant';
@@ -18,6 +19,12 @@ function createChatListItem(chatID) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (!isLoggedIn()) {
+    sessionStorage.setItem('redirectAfterLogin', window.location.pathname);
+    window.location.href = '/auth/login.html';
+    return;
+  }
+
   const newChatBtn = document.getElementById('newChatButton');
   const chatList = document.getElementById('chatList');
   if (!newChatBtn) return;


### PR DESCRIPTION
## Summary
- enforce auth on chat page using user cache
- allow redirect to previous page after login

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683cf2eee9b083319daf3d278d2f8068