### PR TITLE
Add chat names to history

### DIFF
--- a/public/auth/idgenerator.html
+++ b/public/auth/idgenerator.html
@@ -84,8 +84,8 @@
         createdAt: Date.now()
       });
 
-      // Add session to user's chatSessions
-      await update(ref(db, `users/${user.uid}/chatSessions`), { [sessionUID]: true });
+      // Add session to user's chatHistory
+      await update(ref(db, `users/${user.uid}/chatHistory`), { [sessionUID]: true });
 
       return sessionUID;
     }
@@ -99,15 +99,15 @@
         [user.uid]: { wallet: walletAddress, blocked: false }
       });
 
-      // Add session to user's chatSessions
-      await update(ref(db, `users/${user.uid}/chatSessions`), { [sessionUID]: true });
+        // Add session to user's chatHistory
+        await update(ref(db, `users/${user.uid}/chatHistory`), { [sessionUID]: true });
     }
 
     async function sendMessage(sessionUID, text, sender = null) {
       const user = auth.currentUser;
       if (!user && !sender) throw new Error("Not logged in");
 
-      const msgRef = push(ref(db, `chatSessions/${sessionUID}/messages`));
+      const msgRef = push(ref(db, `users/${user.uid}/chatHistory/${sessionUID}/messages`));
       await set(msgRef, {
         sender: sender || user.uid,
         text,
@@ -117,7 +117,7 @@
     }
 
     function listenForMessages(sessionUID, onMessage) {
-      const messagesRef = ref(db, `chatSessions/${sessionUID}/messages`);
+      const messagesRef = ref(db, `users/${auth.currentUser.uid}/chatHistory/${sessionUID}/messages`);
       onChildAdded(messagesRef, (snapshot) => {
         onMessage(snapshot.val());
       });
@@ -127,22 +127,22 @@
       const user = auth.currentUser;
       if (!user) throw new Error("Not logged in");
 
-      const messagesRef = ref(db, `chatSessions/${sessionUID}/messages`);
+      const messagesRef = ref(db, `users/${user.uid}/chatHistory/${sessionUID}/messages`);
       const snapshot = await get(messagesRef);
       snapshot.forEach(child => {
         const msgKey = child.key;
-        update(ref(db, `chatSessions/${sessionUID}/messages/${msgKey}/readBy`), {
+        update(ref(db, `users/${user.uid}/chatHistory/${sessionUID}/messages/${msgKey}/readBy`), {
           [user.uid]: true
         });
       });
     }
 
     async function kickUserFromSession(sessionUID, targetUid) {
-      await update(ref(db, `chatSessions/${sessionUID}/participants/${targetUid}`), { blocked: true });
+      await update(ref(db, `users/${auth.currentUser.uid}/chatHistory/${sessionUID}/participants/${targetUid}`), { blocked: true });
     }
 
     async function removeChatSession(sessionUID) {
-      await set(ref(db, `chatSessions/${sessionUID}`), null);
+      await set(ref(db, `users/${auth.currentUser.uid}/chatHistory/${sessionUID}`), null);
     }
 
     let currentSessionUID = null;
@@ -176,7 +176,7 @@
 
     function checkForUnread(sessionUID) {
       const user = auth.currentUser;
-      const messagesRef = ref(db, `chatSessions/${sessionUID}/messages`);
+      const messagesRef = ref(db, `users/${user.uid}/chatHistory/${sessionUID}/messages`);
       get(messagesRef).then(snapshot => {
         let hasUnread = false;
         snapshot.forEach(child => {

--- a/public/code/chatSystem/chat-ui.js
+++ b/public/code/chatSystem/chat-ui.js
@@ -1,9 +1,9 @@
-import { startNewChatWithUser } from './astranetSDKChat.js';
+import { startNewChatWithUser, loadUserChatList } from './astranetSDKChat.js';
 
 // UID of the default assistant account used for new conversations
 const DEFAULT_PARTNER_UID = 'astranet-assistant';
 
-function createChatListItem(chatID) {
+function createChatListItem(chatID, chatName) {
   const item = document.createElement('div');
   item.className = 'flex items-center gap-4 bg-white px-4 min-h-14';
   item.innerHTML = `
@@ -12,7 +12,7 @@ function createChatListItem(chatID) {
         <path d="M140,128a12,12,0,1,1-12-12A12,12,0,0,1,140,128ZM84,116a12,12,0,1,0,12,12A12,12,0,0,0,84,116Zm88,0a12,12,0,1,0,12,12A12,12,0,0,0,172,116Zm60,12A104,104,0,0,1,79.12,219.82L45.07,231.17a16,16,0,0,1-20.24-20.24l11.35-34.05A104,104,0,1,1,232,128Zm-16,0A88,88,0,1,0,51.81,172.06a8,8,0,0,1,.66,6.54L40,216,77.4,203.53a7.85,7.85,0,0,1,2.53-.42,8,8,0,0,1,4,1.08A88,88,0,0,0,216,128Z"></path>
       </svg>
     </div>
-    <p class="text-[#111418] text-base font-normal leading-normal flex-1 truncate">${chatID}</p>
+    <p class="text-[#111418] text-base font-normal leading-normal flex-1 truncate">${chatName}</p>
   `;
   return item;
 }
@@ -22,13 +22,21 @@ document.addEventListener('DOMContentLoaded', () => {
   const chatList = document.getElementById('chatList');
   if (!newChatBtn) return;
 
+  // Load existing chats on startup
+  loadUserChatList().then(chats => {
+    if (!chatList) return;
+    chats.forEach(({ chatID, name }) => {
+      chatList.appendChild(createChatListItem(chatID, name || chatID));
+    });
+  });
+
   newChatBtn.addEventListener('click', async () => {
     try {
       const chatID = await startNewChatWithUser(DEFAULT_PARTNER_UID);
       console.log('New chat started with ID:', chatID);
-      if (chatList) {
-        chatList.appendChild(createChatListItem(chatID));
-      }
+        if (chatList) {
+          chatList.appendChild(createChatListItem(chatID, 'Nuevo chat'));
+        }
       if (window.popupNotifier) {
         popupNotifier.success('Conversación iniciada', 'Chat');
       }


### PR DESCRIPTION
## Summary
- support naming chats when creating a chat session
- load saved chats from `chatHistory`
- adjust UID generator sample to use `chatHistory`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d366ac0448331b50e9eae126d5ca8