### PR TITLE
Improve chat sidebar layout

### DIFF
--- a/public/astranet/chat.html
+++ b/public/astranet/chat.html
@@ -28,30 +28,8 @@
         <div class="flex h-full grow">
           <!-- Chat History Panel -->
           <div class="layout-content-container flex flex-col w-80 min-w-[320px] border-r border-gray-200">
-            <div class="px-4 py-3">
-              <label class="flex flex-col min-w-40 h-12 w-full">
-                <div class="flex w-full flex-1 items-stretch rounded-lg h-full">
-                  <div
-                    class="text-[#60758a] flex border-none bg-[#f0f2f5] items-center justify-center pl-4 rounded-l-lg border-r-0"
-                    data-icon="MagnifyingGlass"
-                    data-size="24px"
-                    data-weight="regular"
-                  >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-                      <path
-                        d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
-                      ></path>
-                    </svg>
-                  </div>
-                  <input
-                    placeholder="Search conversations"
-                    class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-lg text-[#111418] focus:outline-0 focus:ring-0 border-none bg-[#f0f2f5] focus:border-none h-full placeholder:text-[#60758a] px-4 rounded-l-none border-l-0 pl-2 text-base font-normal leading-normal"
-                    value=""
-                  />
-                </div>
-              </label>
-            </div>
-            <button id="newChatButton" type="button" class="flex items-center gap-4 bg-white px-4 min-h-14 w-full text-left focus-visible:outline-none">
+            <div id="contentSideBarLeft" class="flex flex-col flex-1 overflow-y-auto">
+              <button id="newChatButton" type="button" class="flex items-center gap-4 bg-white px-4 min-h-14 w-full text-left focus-visible:outline-none">
               <div class="text-[#111418] flex items-center justify-center rounded-lg bg-[#f0f2f5] shrink-0 size-10" data-icon="Plus" data-size="24px" data-weight="regular">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                   <path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path>


### PR DESCRIPTION
## Summary
- restructure sidebar markup to wrap chat list in `contentSideBarLeft`
- remove conversation search bar

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_683d3b6ea6188331a3cf2623191a88d6